### PR TITLE
Add MAC Validation Skip on FetchAppState

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -54,7 +54,7 @@ func (cli *Client) FetchAppState(name appstate.WAPatchName, fullSync, onlyIfNotS
 		}
 		hasMore = patches.HasMorePatches
 
-		mutations, newState, err := cli.appStateProc.DecodePatches(patches, state, true)
+		mutations, newState, err := cli.appStateProc.DecodePatches(patches, state, !cli.DisableMACsValidationOnFetchAppState)
 		if err != nil {
 			if errors.Is(err, appstate.ErrKeyNotFound) {
 				go cli.requestMissingAppStateKeys(context.TODO(), patches)

--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ type Client struct {
 	// even when re-syncing the whole state.
 	EmitAppStateEventsOnFullSync bool
 
-	// DisableMACsValidationOnFetchAppState cah be set to true if want to skip MAC validation
+	// can be set to true if want to skip MAC validation
 	DisableMACsValidationOnFetchAppState bool
 
 	AutomaticMessageRerequestFromPhone bool

--- a/client.go
+++ b/client.go
@@ -74,6 +74,9 @@ type Client struct {
 	// even when re-syncing the whole state.
 	EmitAppStateEventsOnFullSync bool
 
+	// DisableMACsValidationOnFetchAppState cah be set to true if want to skip MAC validation
+	DisableMACsValidationOnFetchAppState bool
+
 	AutomaticMessageRerequestFromPhone bool
 	pendingPhoneRerequests             map[types.MessageID]context.CancelFunc
 	pendingPhoneRerequestsLock         sync.RWMutex

--- a/mdtest/go.mod
+++ b/mdtest/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mdp/qrterminal/v3 v3.0.0
-	go.mau.fi/whatsmeow v0.0.0-20230805111647-405414b9b5c0
+	go.mau.fi/whatsmeow v0.0.0-20240327124018-350073db195c
 	google.golang.org/protobuf v1.33.0
 )
 


### PR DESCRIPTION
# **Background**
When using FetchAppState, for fetching all label(s), there is a function to validate patch MACs. The problem is when we Create a label from Another Device or from Whatsapp Web, then update the Created Label(s) from Origin Device, its will generating error(s) when validating the MACs. 

`failed to decode app state regular patches: failed to verify patch v26: mismatching LTHash`

# **Proposed Solution**
On Specific Case, we can disable the ValidationMACs using variable(s) that we set to true or false.

# **Test Result**
![image](https://github.com/evermos/whatsmeow/assets/114892745/bc3d2845-b9c5-4981-923f-355aa3b65a4f)
