### PR TITLE
feat: send appstate event versioning on every occured event

### DIFF
--- a/client.go
+++ b/client.go
@@ -82,6 +82,9 @@ type Client struct {
 	// set up the maximum patch version when performing FetchAppState
 	LatestPatchVersionOnFetch map[appstate.WAPatchName]uint64
 
+	// set up config for enable sent appstate event versioning
+	EnableSentAppstateEventVersioning bool
+
 	AutomaticMessageRerequestFromPhone bool
 	pendingPhoneRerequests             map[types.MessageID]context.CancelFunc
 	pendingPhoneRerequestsLock         sync.RWMutex

--- a/types/events/appstate.go
+++ b/types/events/appstate.go
@@ -187,3 +187,14 @@ type AppState struct {
 type AppStateSyncComplete struct {
 	Name appstate.WAPatchName
 }
+
+// AppStateVersion is emitted when a app state event occurs.
+type AppStateVersion struct {
+	JID               types.JID // The chat which was labeled or unlabeled.
+	Timestamp         time.Time // The time when the (un)labeling happened.
+	AppStateEventType string    // Type of running appstate event.
+	AppStateName      string    // The message id which was labeled or unlabeled.
+	Version           uint64    // The version of appstate on current event
+
+	FromFullSync bool // Whether the action is emitted because of a fullSync
+}


### PR DESCRIPTION
## Background
For optimizing our service, we need store appstate version (currently only for logging). Our planning on the future, this log can transform to data for selecting what data from what state want to be synced. With that process, hopefully can increase efficiency for data sync process.

## Proposed Solution
Send All Appstate Event, focused on Appstate Version to Event Handler

## Test Result
![image](https://github.com/evermos/whatsmeow/assets/114892745/04c94275-39cd-426c-bdaf-3533152a1169)