### PR TITLE
add: initial sync event notifier

### DIFF
--- a/message.go
+++ b/message.go
@@ -507,6 +507,10 @@ func (cli *Client) handleAppStateSyncKeyShare(keys *waProto.AppStateSyncKeyShare
 			cli.Log.Errorf("Failed to do initial fetch of app state %s: %v", name, err)
 		}
 	}
+
+	cli.dispatchEvent(&events.InitialDeviceAppStateSyncFinished{
+		IsFinished: true,
+	})
 }
 
 func (cli *Client) handlePlaceholderResendResponse(msg *waProto.PeerDataOperationRequestResponseMessage) {

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -583,3 +583,7 @@ type NewsletterLiveUpdate struct {
 	Time     time.Time
 	Messages []*types.NewsletterMessage
 }
+
+type InitialDeviceAppStateSyncFinished struct {
+	IsFinished bool
+}


### PR DESCRIPTION
This updates for giving more clear notification, so we can track after initial connection the data is already stored in DB or not with tracking the appstate fetch status.

Usage
![image](https://github.com/user-attachments/assets/018257b3-21c7-47e5-84e8-a75a2603fa7e)


Result
![image](https://github.com/user-attachments/assets/c13cae3c-caa3-4fac-a53f-344edeacea40)
